### PR TITLE
hw11-cache

### DIFF
--- a/hw11-cache/src/main/java/ru/otus/cache/HWCacheDemo.java
+++ b/hw11-cache/src/main/java/ru/otus/cache/HWCacheDemo.java
@@ -1,0 +1,33 @@
+package ru.otus.cache;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class HWCacheDemo {
+    private static final Logger logger = LoggerFactory.getLogger(HWCacheDemo.class);
+
+    public static void main(String[] args) {
+        new HWCacheDemo().demo();
+    }
+
+    private void demo() {
+        HwCache<String, Integer> cache = new MyCache<>();
+
+        // пример, когда Idea предлагает упростить код, при этом может появиться "спец"-эффект
+        cache.addListener(new HwListener<String, Integer>() {
+            @Override
+            public void notify(String key, Integer value, String action) {
+                logger.info("key:{}, value:{}, action: {}", key, value, action);
+            }
+        });
+        cache.addListener((key, value, action) -> logger.info("key:{}, value:{}, action: {}", key, value, action));
+
+        cache.put("1", 1);
+        cache.remove("1");
+
+        System.gc();
+
+        cache.put("2", 2);
+    }
+}

--- a/hw11-cache/src/main/java/ru/otus/cache/HWCacheDemo.java
+++ b/hw11-cache/src/main/java/ru/otus/cache/HWCacheDemo.java
@@ -22,6 +22,9 @@ public class HWCacheDemo {
             }
         });
         cache.addListener((key, value, action) -> logger.info("key:{}, value:{}, action: {}", key, value, action));
+        HwListener<String, Integer> hwListener = (key, value, action) ->
+                logger.info("key:{}, value:{}, action: {}", key, value, action);
+        cache.addListener(hwListener);
 
         cache.put("1", 1);
         cache.remove("1");
@@ -29,5 +32,9 @@ public class HWCacheDemo {
         System.gc();
 
         cache.put("2", 2);
+
+        cache.removeListener(hwListener);
+
+        cache.put("3", 3);
     }
 }

--- a/hw11-cache/src/main/java/ru/otus/cache/HwCache.java
+++ b/hw11-cache/src/main/java/ru/otus/cache/HwCache.java
@@ -1,0 +1,15 @@
+package ru.otus.cache;
+
+
+public interface HwCache<K, V> {
+
+    void put(K key, V value);
+
+    void remove(K key);
+
+    V get(K key);
+
+    void addListener(HwListener<K, V> listener);
+
+    void removeListener(HwListener<K, V> listener);
+}

--- a/hw11-cache/src/main/java/ru/otus/cache/HwListener.java
+++ b/hw11-cache/src/main/java/ru/otus/cache/HwListener.java
@@ -1,0 +1,6 @@
+package ru.otus.cache;
+
+
+public interface HwListener<K, V> {
+    void notify(K key, V value, String action);
+}

--- a/hw11-cache/src/main/java/ru/otus/cache/MyCache.java
+++ b/hw11-cache/src/main/java/ru/otus/cache/MyCache.java
@@ -49,6 +49,7 @@ public class MyCache<K, V> implements HwCache<K, V> {
         for (WeakReference<HwListener<K, V>> listenerReference : listeners) {
             HwListener<K, V> listener = listenerReference.get();
             if (listener != null) {
+                logger.info("call notify on " + listener);
                 listener.notify(key, value, action);
             }
         }

--- a/hw11-cache/src/main/java/ru/otus/cache/MyCache.java
+++ b/hw11-cache/src/main/java/ru/otus/cache/MyCache.java
@@ -1,0 +1,56 @@
+package ru.otus.cache;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+public class MyCache<K, V> implements HwCache<K, V> {
+    private static final Logger logger = LoggerFactory.getLogger(MyCache.class);
+
+    private final Map<K, V> values = new WeakHashMap<>();
+    private final List<WeakReference<HwListener<K, V>>> listeners = new ArrayList<>();
+
+    @Override
+    public void put(K key, V value) {
+        values.put(key, value);
+        notifyListeners(key, value, "put");
+    }
+
+    @Override
+    public void remove(K key) {
+        V removedValue = values.remove(key);
+        notifyListeners(key, removedValue, "remove");
+    }
+
+    @Override
+    public V get(K key) {
+        V value = values.getOrDefault(key, null);
+        notifyListeners(key, value, "get");
+        return value;
+    }
+
+    @Override
+    public void addListener(HwListener<K, V> listener) {
+        listeners.add(new WeakReference<>(listener));
+        logger.info("added new HwListener " + listener);
+    }
+
+    @Override
+    public void removeListener(HwListener<K, V> listener) {
+    }
+
+    private void notifyListeners(K key, V value, String action) {
+        for (WeakReference<HwListener<K, V>> listenerReference : listeners) {
+            HwListener<K, V> listener = listenerReference.get();
+            if (listener != null) {
+                listener.notify(key, value, action);
+            }
+        }
+    }
+}

--- a/hw11-cache/src/main/java/ru/otus/cache/MyCache.java
+++ b/hw11-cache/src/main/java/ru/otus/cache/MyCache.java
@@ -43,6 +43,7 @@ public class MyCache<K, V> implements HwCache<K, V> {
 
     @Override
     public void removeListener(HwListener<K, V> listener) {
+        listeners.removeIf(currListener -> listener.equals(currListener.get()));
     }
 
     private void notifyListeners(K key, V value, String action) {
@@ -51,6 +52,8 @@ public class MyCache<K, V> implements HwCache<K, V> {
             if (listener != null) {
                 logger.info("call notify on " + listener);
                 listener.notify(key, value, action);
+            } else {
+                listeners.remove(listenerReference);
             }
         }
     }

--- a/hw11-cache/src/main/java/ru/otus/orm/service/DbServiceClientCacheImpl.java
+++ b/hw11-cache/src/main/java/ru/otus/orm/service/DbServiceClientCacheImpl.java
@@ -31,11 +31,11 @@ public class DbServiceClientCacheImpl implements DBServiceClient {
                 var clientId = dataTemplate.insert(connection, client);
                 var createdClient = new Client(clientId, client.getName());
                 log.info("created and cached client: {}", createdClient);
-                cache.put(String.valueOf(createdClient.getId()), createdClient);
+                cache.put(createKey(createdClient), createdClient);
                 return createdClient;
             }
             dataTemplate.update(connection, client);
-            cache.put(String.valueOf(client.getId()), client);
+            cache.put(createKey(client), client);
             log.info("updated and cached client: {}", client);
             return client;
         });
@@ -52,7 +52,7 @@ public class DbServiceClientCacheImpl implements DBServiceClient {
                 log.info("client: {}", clientOptional);
                 return clientOptional;
             });
-            optionalClient.ifPresent(client -> cache.put(String.valueOf(client.getId()), client));
+            optionalClient.ifPresent(client -> cache.put(createKey(client), client));
             return optionalClient;
         }
     }
@@ -64,5 +64,9 @@ public class DbServiceClientCacheImpl implements DBServiceClient {
             log.info("clientList:{}", clientList);
             return clientList;
         });
+    }
+
+    private String createKey(Client client) {
+        return String.valueOf(client.getId());
     }
 }

--- a/hw11-cache/src/main/java/ru/otus/orm/service/DbServiceClientCacheImpl.java
+++ b/hw11-cache/src/main/java/ru/otus/orm/service/DbServiceClientCacheImpl.java
@@ -1,0 +1,68 @@
+package ru.otus.orm.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ru.otus.cache.HwCache;
+import ru.otus.orm.model.Client;
+import ru.otus.orm.repository.DataTemplate;
+import ru.otus.orm.sessionmanager.TransactionRunner;
+
+import java.util.List;
+import java.util.Optional;
+
+public class DbServiceClientCacheImpl implements DBServiceClient {
+    private static final Logger log = LoggerFactory.getLogger(DbServiceClientImpl.class);
+
+    private final DataTemplate<Client> dataTemplate;
+    private final TransactionRunner transactionRunner;
+    private final HwCache<String, Client> cache;
+
+    public DbServiceClientCacheImpl(TransactionRunner transactionRunner, DataTemplate<Client> dataTemplate,
+                               HwCache<String, Client> cache) {
+        this.transactionRunner = transactionRunner;
+        this.dataTemplate = dataTemplate;
+        this.cache = cache;
+    }
+
+    @Override
+    public Client saveClient(Client client) {
+        return transactionRunner.doInTransaction(connection -> {
+            if (client.getId() == null) {
+                var clientId = dataTemplate.insert(connection, client);
+                var createdClient = new Client(clientId, client.getName());
+                log.info("created and cached client: {}", createdClient);
+                cache.put(String.valueOf(createdClient.getId()), createdClient);
+                return createdClient;
+            }
+            dataTemplate.update(connection, client);
+            cache.put(String.valueOf(client.getId()), client);
+            log.info("updated and cached client: {}", client);
+            return client;
+        });
+    }
+
+    @Override
+    public Optional<Client> getClient(long id) {
+        Client cachedClient = cache.get(String.valueOf(id));
+        if (cachedClient != null) {
+            return Optional.of(cachedClient);
+        } else {
+            Optional<Client> optionalClient = transactionRunner.doInTransaction(connection -> {
+                var clientOptional = dataTemplate.findById(connection, id);
+                log.info("client: {}", clientOptional);
+                return clientOptional;
+            });
+            optionalClient.ifPresent(client -> cache.put(String.valueOf(client.getId()), client));
+            return optionalClient;
+        }
+    }
+
+    @Override
+    public List<Client> findAll() {
+        return transactionRunner.doInTransaction(connection -> {
+            var clientList = dataTemplate.findAll(connection);
+            log.info("clientList:{}", clientList);
+            return clientList;
+        });
+    }
+}


### PR DESCRIPTION
Скорость работы DBService без кэша:
- Сохранение клиента - 10 ms
- Получение клиента - 5 ms

С кэшом:
- Сохранение клиента - 10 ms
- Получение клиента - 0 ms

Получение 1000 клиентов:
- Используя кэш - 784 ms
- После сборки мусора, используя кэш - 1283 ms

Также выводы по добавлению Weak Reference HWListener-ов в кэш:
- Listener, созданный с помощью анонимного класса, после сборки мусора удалился
- Listener, созданный с помощью лямда-функции, после сборки мусора остался